### PR TITLE
Force load order for compatibility.

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -26,3 +26,15 @@ mandatory = true
 versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "BOTH"
+[[dependencies.${mod_id}]]
+modId = "sophisticatedcore"
+mandatory = false
+versionRange = "*"
+ordering = "AFTER"
+side = "BOTH"
+[[dependencies.${mod_id}]]
+modId = "sophisticatedstorage"
+mandatory = false
+versionRange = "*"
+ordering = "AFTER"
+side = "BOTH"


### PR DESCRIPTION
In commits on June 9th the sophisticated system changed how network instances are handled and now requires the mod to be loaded. I added load order to prevent crashing.