### PR TITLE
First attempt at fixing #101

### DIFF
--- a/common/src/main/java/com/github/smallinger/copperagebackport/item/armor/CopperArmorMaterial.java
+++ b/common/src/main/java/com/github/smallinger/copperagebackport/item/armor/CopperArmorMaterial.java
@@ -2,10 +2,12 @@ package com.github.smallinger.copperagebackport.item.armor;
 
 import com.github.smallinger.copperagebackport.Constants;
 import com.github.smallinger.copperagebackport.ModSounds;
+import com.github.smallinger.copperagebackport.registry.RegistryHelper;
 import net.minecraft.Util;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
@@ -38,10 +40,10 @@ public class CopperArmorMaterial {
         map.put(ArmorItem.Type.HELMET, 2);
         map.put(ArmorItem.Type.BODY, 4);
     });
+
+    public static Supplier<ArmorMaterial> COPPER;
     
-    public static Supplier<Holder<ArmorMaterial>> COPPER;
-    
-    private static Holder<ArmorMaterial> createCopper() {
+    private static void createCopper() {
         ResourceLocation location = ResourceLocation.withDefaultNamespace("copper");
         List<ArmorMaterial.Layer> layers = List.of(new ArmorMaterial.Layer(location));
         
@@ -49,17 +51,17 @@ public class CopperArmorMaterial {
         for (ArmorItem.Type type : ArmorItem.Type.values()) {
             enummap.put(type, DEFENSE.get(type));
         }
-        
+        RegistryHelper helper = RegistryHelper.getInstance();
         // Use our custom copper equip sound - defer the sound lookup
-        Holder<SoundEvent> equipSound = Holder.direct(ModSounds.ARMOR_EQUIP_COPPER.get());
-        
-        return Registry.registerForHolder(BuiltInRegistries.ARMOR_MATERIAL, location,
-                new ArmorMaterial(enummap, 8, equipSound, () -> Ingredient.of(Items.COPPER_INGOT), layers, 0.0F, 0.0F));
+        Holder<SoundEvent> equipSound = helper.hackilyGetEquipSoundHolder();
+
+        COPPER = helper.registerAuto(Registries.ARMOR_MATERIAL, "copper", () -> new ArmorMaterial(enummap, 8, equipSound, () -> Ingredient.of(Items.COPPER_INGOT), layers, 0.0F, 0.0F));
+
     }
     
     public static void init() {
         // Force static initialization and create the armor material supplier
         Constants.LOG.info("Registering Copper Armor Material for {}", Constants.MOD_NAME);
-        COPPER = () -> createCopper();
+        createCopper();
     }
 }

--- a/common/src/main/java/com/github/smallinger/copperagebackport/registry/ModItems.java
+++ b/common/src/main/java/com/github/smallinger/copperagebackport/registry/ModItems.java
@@ -405,22 +405,22 @@ public class ModItems {
         
         // Copper Armor
         COPPER_HELMET = helper.registerAuto(ITEM, "copper_helmet",
-            () -> new ArmorItem(com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial.COPPER.get(), ArmorItem.Type.HELMET, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.HELMET.getDurability(11))));
+            () -> new ArmorItem(helper.hackilyGetArmorMaterialHolder(), ArmorItem.Type.HELMET, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.HELMET.getDurability(11))));
         
         COPPER_CHESTPLATE = helper.registerAuto(ITEM, "copper_chestplate",
-            () -> new ArmorItem(com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial.COPPER.get(), ArmorItem.Type.CHESTPLATE, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.CHESTPLATE.getDurability(11))));
+            () -> new ArmorItem(helper.hackilyGetArmorMaterialHolder(), ArmorItem.Type.CHESTPLATE, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.CHESTPLATE.getDurability(11))));
         
         COPPER_LEGGINGS = helper.registerAuto(ITEM, "copper_leggings",
-            () -> new ArmorItem(com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial.COPPER.get(), ArmorItem.Type.LEGGINGS, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.LEGGINGS.getDurability(11))));
+            () -> new ArmorItem(helper.hackilyGetArmorMaterialHolder(), ArmorItem.Type.LEGGINGS, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.LEGGINGS.getDurability(11))));
         
         COPPER_BOOTS = helper.registerAuto(ITEM, "copper_boots",
-            () -> new ArmorItem(com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial.COPPER.get(), ArmorItem.Type.BOOTS, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.BOOTS.getDurability(11))));
+            () -> new ArmorItem(helper.hackilyGetArmorMaterialHolder(), ArmorItem.Type.BOOTS, new Item.Properties().stacksTo(1).durability(ArmorItem.Type.BOOTS.getDurability(11))));
         
         // Copper Horse Armor: 4 protection (between leather 3 and iron 5)
         // 1.21.1 uses AnimalArmorItem which derives texture path from ArmorMaterial key (copperagebackport:copper)
         // -> automatically looks for: copperagebackport:textures/entity/horse/armor/horse_armor_copper.png
         // Note: 1.20.1 uses custom CopperHorseArmorItem class because HorseArmorItem only supports minecraft namespace
         COPPER_HORSE_ARMOR = helper.registerAuto(ITEM, "copper_horse_armor",
-            () -> new AnimalArmorItem(com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial.COPPER.get(), AnimalArmorItem.BodyType.EQUESTRIAN, false, new Item.Properties().stacksTo(1)));
+            () -> new AnimalArmorItem(helper.hackilyGetArmorMaterialHolder(), AnimalArmorItem.BodyType.EQUESTRIAN, false, new Item.Properties().stacksTo(1)));
     }
 }

--- a/common/src/main/java/com/github/smallinger/copperagebackport/registry/RegistryHelper.java
+++ b/common/src/main/java/com/github/smallinger/copperagebackport/registry/RegistryHelper.java
@@ -1,9 +1,12 @@
 package com.github.smallinger.copperagebackport.registry;
 
 import com.github.smallinger.copperagebackport.Constants;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.item.ArmorMaterial;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -220,6 +223,10 @@ public abstract class RegistryHelper {
     public <T> Supplier<T> registerAuto(ResourceKey<? extends Registry<? super T>> registry, String name, Supplier<T> supplier) {
         return registerWithNamespace(registry, MINECRAFT_NAMESPACE, name, supplier);
     }
+
+    // hacky as all hell but
+    public abstract Holder<SoundEvent> hackilyGetEquipSoundHolder();
+    public abstract Holder<ArmorMaterial> hackilyGetArmorMaterialHolder();
     
     public void onRegisterComplete(Runnable callback) {
         registrationCallbacks.add(callback);

--- a/fabric/src/main/java/com/github/smallinger/copperagebackport/fabric/platform/FabricRegistryHelper.java
+++ b/fabric/src/main/java/com/github/smallinger/copperagebackport/fabric/platform/FabricRegistryHelper.java
@@ -1,12 +1,18 @@
 package com.github.smallinger.copperagebackport.fabric.platform;
 
 import com.github.smallinger.copperagebackport.Constants;
+import com.github.smallinger.copperagebackport.ModSounds;
+import com.github.smallinger.copperagebackport.item.armor.CopperArmorMaterial;
 import com.github.smallinger.copperagebackport.registry.RegistryHelper;
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.item.ArmorMaterial;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +78,16 @@ public class FabricRegistryHelper extends RegistryHelper {
         Constants.LOG.debug("Registered {} under namespace {}", name, namespace);
         
         return () -> registered;
+    }
+
+    @Override
+    public Holder<SoundEvent> hackilyGetEquipSoundHolder() {
+        return Holder.direct(ModSounds.ARMOR_EQUIP_COPPER.get());
+    }
+
+    @Override
+    public Holder<ArmorMaterial> hackilyGetArmorMaterialHolder() {
+        return BuiltInRegistries.ARMOR_MATERIAL.getHolder(ResourceLocation.withDefaultNamespace("copper")).orElseThrow();
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ forge_version=52.0.28
 forge_loader_version_range=[52,)
 
 # NeoForge
-neoforge_version=21.1.115
+neoforge_version=21.1.242
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/neoforge/src/main/java/com/github/smallinger/copperagebackport/neoforge/platform/NeoForgeRegistryHelper.java
+++ b/neoforge/src/main/java/com/github/smallinger/copperagebackport/neoforge/platform/NeoForgeRegistryHelper.java
@@ -2,9 +2,15 @@ package com.github.smallinger.copperagebackport.neoforge.platform;
 
 import com.github.smallinger.copperagebackport.Constants;
 import com.github.smallinger.copperagebackport.registry.RegistryHelper;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.item.ArmorMaterial;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 import java.util.HashMap;
@@ -51,6 +57,16 @@ public class NeoForgeRegistryHelper extends RegistryHelper {
         });
 
         return register.register(name, supplier);
+    }
+
+    @Override
+    public Holder<SoundEvent> hackilyGetEquipSoundHolder() {
+        return DeferredHolder.create(Registries.SOUND_EVENT, ResourceLocation.withDefaultNamespace("item.armor.equip_copper"));
+    }
+
+    @Override
+    public Holder<ArmorMaterial> hackilyGetArmorMaterialHolder() {
+        return DeferredHolder.create(Registries.ARMOR_MATERIAL, ResourceLocation.withDefaultNamespace("copper"));
     }
 
     @Override


### PR DESCRIPTION
Closes #101. Uses @madpunkmax-jpg's fix from the issue submission, but required a lot more changes after that as well, because createCopper() was registering the material directly instead of using the RegistryHelper (and then trying to fix that caused registration errors on Fabric instead). This attempt has a lot of bad-practice stuff in it, but at least it does work on both NeoForge and Fabric.