### PR TITLE
Register copper armor material only once

### DIFF
--- a/common/src/main/java/com/github/smallinger/copperagebackport/item/armor/CopperArmorMaterial.java
+++ b/common/src/main/java/com/github/smallinger/copperagebackport/item/armor/CopperArmorMaterial.java
@@ -40,7 +40,11 @@ public class CopperArmorMaterial {
     });
     
     public static Supplier<Holder<ArmorMaterial>> COPPER;
-    
+
+    // createCopper() registers into BuiltInRegistries.ARMOR_MATERIAL, so it must run only once.
+    // ModItems calls COPPER.get() once per armor piece, so the holder is cached here.
+    private static Holder<ArmorMaterial> copperHolder;
+
     private static Holder<ArmorMaterial> createCopper() {
         ResourceLocation location = ResourceLocation.withDefaultNamespace("copper");
         List<ArmorMaterial.Layer> layers = List.of(new ArmorMaterial.Layer(location));
@@ -60,6 +64,11 @@ public class CopperArmorMaterial {
     public static void init() {
         // Force static initialization and create the armor material supplier
         Constants.LOG.info("Registering Copper Armor Material for {}", Constants.MOD_NAME);
-        COPPER = () -> createCopper();
+        COPPER = () -> {
+            if (copperHolder == null) {
+                copperHolder = createCopper();
+            }
+            return copperHolder;
+        };
     }
 }


### PR DESCRIPTION
CopperArmorMaterial.COPPER was a plain, non-memoized Supplier whose body calls createCopper(), and createCopper() registers into BuiltInRegistries.ARMOR_MATERIAL via Registry.registerForHolder. ModItems calls COPPER.get() five times (helmet, chestplate, leggings, boots, horse armor), so the second call re-registers minecraft:copper and throws:

  java.lang.IllegalStateException: Adding duplicate key
  'ResourceKey[minecraft:armor_material / minecraft:copper]' to registry
    at CopperArmorMaterial.createCopper(CopperArmorMaterial.java:56)
    at CopperArmorMaterial.lambda$init$2(CopperArmorMaterial.java:63)
    at ModItems.lambda$register$75(ModItems.java:411)

On NeoForge this aborts the item RegisterEvent, so every mod dispatched after copperagebackport fails to register its items. The result is a broken mod state that takes down unrelated mods and crashes the client during startup.

Cache the holder so the registration happens exactly once. All callers run on the registration thread, so no synchronization is needed.